### PR TITLE
Remove marked from dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,8 +86,7 @@
     "d3-drag": "1.2.3",
     "d3-selection": "1.4.0",
     "d3-shape": "1.0.4",
-    "d3-transition": "1.0.3",
-    "marked": "0.3.9"
+    "d3-transition": "1.0.3"
   },
   "homepage": "http://d3-annotation.susielu.com"
 }


### PR DESCRIPTION
Removed marked from dependency it is causing security alerts when it's not even in use, it is already present in devDependencies.